### PR TITLE
Fix: cancelling a waste-pile lift no longer ends your turn

### DIFF
--- a/app/js/services/playboard_service.js
+++ b/app/js/services/playboard_service.js
@@ -70,6 +70,11 @@ export function makeMove(game, move, isAllowedMove) {
         && move.getTargetPilePosition() == PileUtils.getReservePilePositionOfPlayer(move.getPlayer())) {
         isNullMove = true;
     }
+    // Move from own waste pile to own waste pile (player lifted the top card and dropped it back to cancel):
+    else if(move.getSourcePilePosition() == PileUtils.getWastePilePositionOfPlayer(move.getPlayer())
+        && move.getTargetPilePosition() == PileUtils.getWastePilePositionOfPlayer(move.getPlayer())) {
+        isNullMove = true;
+    }
 
     if(isAllowedMove && !isNullMove) {
         addMoveToMoveHistory(playboard, move);


### PR DESCRIPTION
## Summary

Fixes a turn-handling bug: **lifting the top card of your own waste pile and dropping it back onto the same pile — i.e. cancelling the lift — incorrectly ended your turn** (and recorded a phantom move), handing play to the AI even though nothing actually moved.

## Root cause

In Russian Bank you end your turn by playing a card *onto* your own waste pile *from elsewhere* (reserve/house). `Game.checkForChangeOnActivePlayer()` ends the turn for **any** move whose target is the player's own waste pile:

```js
// game.js
checkForChangeOnActivePlayer(move) {
    if (move.getTargetPilePosition() == PileUtils.getWastePilePositionOfPlayer(move.getPlayer())) {
        this.setActivePlayer(PlayerUtils.getOpponentPlayer(move.getPlayer()));
    }
}
```

`makeMove()` already neutralises self-drops (drop a card back where it came from) as **null moves** for house→same-house and reserve→same-reserve — they skip history + turn-change. But the **waste→same-waste** case was missing, so dragging the waste card and dropping it back was treated as a real, turn-ending move. (Such a move *is* allowed by the rules check, `isMoveAllowedBasedOnCard`, so it reaches `makeMove` with `isAllowedMove === true`.)

## The fix

One branch in `playboard_service.makeMove()`, mirroring the existing reserve/house self-drop handling:

```js
// Move from own waste pile to own waste pile (player lifted the top card and dropped it back to cancel):
else if (move.getSourcePilePosition() == PileUtils.getWastePilePositionOfPlayer(move.getPlayer())
      && move.getTargetPilePosition() == PileUtils.getWastePilePositionOfPlayer(move.getPlayer())) {
    isNullMove = true;
}
```

`changePlayboard()` still runs (it pops then pushes the same card back — a visual no-op that preserves face-up state), but the move is no longer recorded and no longer ends the turn.

## Code review

Reviewed across two independent multi-finder passes (correctness line-scan, removed-behavior, cross-file caller tracing, altitude/generalization, gameplay-regression, edge cases). All candidate concerns were verified against the source and refuted:
- **face-up loss on pop/push** — refuted: `changePlayboard` copies face-up from the old top element to the newly-pushed one; verified empirically (card stays face-up).
- **move-history "gaps" breaking AI knock detection** — refuted: history is keyed by `size + 1` (dense keys, no gaps), and the existing house/reserve self-drop null moves already skip recording; a cancel no longer changes the turn, so it doesn't even trigger the AI.
- **AI looping / regressions** — refuted: the AI ends its turn via a reserve→waste move and never generates a waste→same-waste move, so the new branch only affects the human cancel gesture.

A deeper generalization (collapse the three self-drop branches into a single `source == target` check) is possible and arguably cleaner, but kept out of this PR to keep the change minimal and to avoid leaving the now-unused `PileType.HOUSE` import (the repo's eslint config flags unused vars). Happy to fold that in if preferred.

## Manual QA (run with `agent-browser` on localhost)

| Test | Result |
|------|--------|
| Waste→same-waste cancel (this fix) | ✅ no-op — turn kept (`PLAYER_A`), no history entry, card unchanged |
| Same gesture on pre-fix build | 🐞 bug reproduced — turn wrongly flipped to `PLAYER_B`, phantom move recorded |
| House→own-waste (legit turn-ender) | ✅ still ends the turn — guard is not over-broad |
| House→same-house self-drop | ✅ still a no-op — pre-existing behavior intact |

## Live demo

Playable build of this branch: **https://jmangel.github.io/russian-bank/app/pages/game.html**

To reproduce the original behavior vs. the fix: pick up the face-up card on your (bottom-right) waste pile and drop it straight back onto the same pile — with the fix it stays your turn; on `main` it hands the turn to the computer.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
